### PR TITLE
Fix error not well-formed at xml file

### DIFF
--- a/res/values-nl-rNL/cr_strings.xml
+++ b/res/values-nl-rNL/cr_strings.xml
@@ -1,4 +1,4 @@
-?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
      Copyright (C) 2016-2024 crDroid Android Project
 


### PR DESCRIPTION
Refer to following error

res/values-nl-rNL/cr_strings.xml:0: error: xml parser error: not well-formed (invalid token).